### PR TITLE
Feat/#9-4: 회원 탈퇴시 쿠키 삭제 & jti로 블랙리스트 보안 강화

### DIFF
--- a/src/main/java/com/project/dasihaebom/domain/user/worker/controller/WorkerController.java
+++ b/src/main/java/com/project/dasihaebom/domain/user/worker/controller/WorkerController.java
@@ -17,6 +17,8 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.concurrent.TimeUnit;
 
+import static com.project.dasihaebom.global.constant.common.CommonConstants.ACCESS_COOKIE_NAME;
+import static com.project.dasihaebom.global.constant.common.CommonConstants.REFRESH_COOKIE_NAME;
 import static com.project.dasihaebom.global.util.CookieUtils.createJwtCookies;
 import static com.project.dasihaebom.global.util.CookieUtils.getTokenFromCookies;
 
@@ -55,13 +57,13 @@ public class WorkerController {
             HttpServletRequest request,
             HttpServletResponse response
     ) {
-        final String accessToken = getTokenFromCookies(request, "access-token");
-        final String refreshToken = getTokenFromCookies(request, "refresh-token");
+        final String accessToken = getTokenFromCookies(request, ACCESS_COOKIE_NAME);
+        final String refreshToken = getTokenFromCookies(request, REFRESH_COOKIE_NAME);
 
         workerCommandService.deleteUser(currentUser.getId(), currentUser.getRole(), accessToken, refreshToken);
 
-        createJwtCookies(response, "access-token", null, 0);
-        createJwtCookies(response, "refresh-token", null, 0);
+        createJwtCookies(response, ACCESS_COOKIE_NAME, null, 0);
+        createJwtCookies(response, REFRESH_COOKIE_NAME, null, 0);
 
         return CustomResponse.onSuccess(HttpStatus.NO_CONTENT, "회원 탈퇴 성공");
     }

--- a/src/main/java/com/project/dasihaebom/domain/user/worker/service/command/WorkerCommandService.java
+++ b/src/main/java/com/project/dasihaebom/domain/user/worker/service/command/WorkerCommandService.java
@@ -9,5 +9,5 @@ public interface WorkerCommandService {
 
     void updateWorker(WorkerReqDto.WorkerUpdateReqDto workerUpdateReqDto, long workerId);
 
-    void deleteUser(long userId, Role role);
+    void deleteUser(long userId, Role role, String accessToken, String refreshToken);
 }

--- a/src/main/java/com/project/dasihaebom/domain/user/worker/service/command/WorkerCommandServiceImpl.java
+++ b/src/main/java/com/project/dasihaebom/domain/user/worker/service/command/WorkerCommandServiceImpl.java
@@ -109,23 +109,17 @@ public class WorkerCommandServiceImpl implements WorkerCommandService {
             Worker worker = workerRepository.findById(userId)
                     .orElseThrow(() -> new WorkerException(WorkerErrorCode.WORKER_NOT_FOUND));
             workerRepository.delete(worker);
-            saveBlackListToken(worker.getPhoneNumber(), accessToken, refreshToken);
+            jwtUtil.saveBlackListToken(worker.getPhoneNumber(), accessToken, refreshToken);
         }
         if (role == Role.CORP) {
             Corp corp = corpRepository.findById(userId)
                     .orElseThrow(() -> new CorpException(CorpErrorCode.CORP_NOT_FOUND));
             corpRepository.delete(corp);
-            saveBlackListToken(corp.getLoginId(), accessToken, refreshToken);
+            jwtUtil.saveBlackListToken(corp.getLoginId(), accessToken, refreshToken);
         }
     }
 
-    private void saveBlackListToken(String loginId, String accessToken, String refreshToken) {
-        // 회원탈퇴 블랙리스트 등록
-        redisUtils.save(loginId + KEY_REFRESH_TOKEN_SUFFIX, refreshToken, jwtUtil.getRefreshExpMs(), TimeUnit.MILLISECONDS);
-        redisUtils.save(loginId + KEY_ACCESS_TOKEN_SUFFIX, accessToken, jwtUtil.getAccessExpMs(), TimeUnit.MILLISECONDS);
-        // 리프레시 정보 삭제
-        redisUtils.delete(loginId + ":refresh");
-    }
+
 
     private String encodePassword(String rawPassword) {
         return passwordEncoder.encode(rawPassword);

--- a/src/main/java/com/project/dasihaebom/domain/user/worker/service/command/WorkerCommandServiceImpl.java
+++ b/src/main/java/com/project/dasihaebom/domain/user/worker/service/command/WorkerCommandServiceImpl.java
@@ -15,6 +15,7 @@ import com.project.dasihaebom.domain.user.worker.exception.WorkerErrorCode;
 import com.project.dasihaebom.domain.user.worker.exception.WorkerException;
 import com.project.dasihaebom.domain.user.worker.repository.WorkerRepository;
 import com.project.dasihaebom.global.client.location.coordinate.CoordinateClient;
+import com.project.dasihaebom.global.security.utils.JwtUtil;
 import com.project.dasihaebom.global.util.RedisUtils;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -26,8 +27,9 @@ import org.springframework.stereotype.Service;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
-import static com.project.dasihaebom.global.constant.redis.RedisConstants.KEY_SCOPE_SUFFIX;
+import static com.project.dasihaebom.global.constant.redis.RedisConstants.*;
 import static com.project.dasihaebom.global.constant.scope.ScopeConstants.SCOPE_SIGNUP;
 import static com.project.dasihaebom.global.util.UpdateUtils.updateIfChanged;
 
@@ -48,6 +50,7 @@ public class WorkerCommandServiceImpl implements WorkerCommandService {
     private final CoordinateClient coordinateClient;
 
     private final RedisUtils<String> redisUtils;
+    private final JwtUtil jwtUtil;
     private final LocationRepository locationRepository;
     private final CorpRepository corpRepository;
 
@@ -101,17 +104,27 @@ public class WorkerCommandServiceImpl implements WorkerCommandService {
     }
 
     @Override
-    public void deleteUser(long userId, Role role) {
+    public void deleteUser(long userId, Role role, String accessToken, String refreshToken) {
         if (role == Role.WORKER) {
             Worker worker = workerRepository.findById(userId)
                     .orElseThrow(() -> new WorkerException(WorkerErrorCode.WORKER_NOT_FOUND));
             workerRepository.delete(worker);
+            saveBlackListToken(worker.getPhoneNumber(), accessToken, refreshToken);
         }
         if (role == Role.CORP) {
             Corp corp = corpRepository.findById(userId)
                     .orElseThrow(() -> new CorpException(CorpErrorCode.CORP_NOT_FOUND));
             corpRepository.delete(corp);
+            saveBlackListToken(corp.getLoginId(), accessToken, refreshToken);
         }
+    }
+
+    private void saveBlackListToken(String loginId, String accessToken, String refreshToken) {
+        // 회원탈퇴 블랙리스트 등록
+        redisUtils.save(loginId + KEY_REFRESH_TOKEN_SUFFIX, refreshToken, jwtUtil.getRefreshExpMs(), TimeUnit.MILLISECONDS);
+        redisUtils.save(loginId + KEY_ACCESS_TOKEN_SUFFIX, accessToken, jwtUtil.getAccessExpMs(), TimeUnit.MILLISECONDS);
+        // 리프레시 정보 삭제
+        redisUtils.delete(loginId + ":refresh");
     }
 
     private String encodePassword(String rawPassword) {

--- a/src/main/java/com/project/dasihaebom/global/constant/common/CommonConstants.java
+++ b/src/main/java/com/project/dasihaebom/global/constant/common/CommonConstants.java
@@ -4,4 +4,8 @@ public class CommonConstants {
 
     // TEMP PASSWORD
     public static final int PASSWORD_SIZE = 10;
+
+    // COOKIE NAME
+    public static final String ACCESS_COOKIE_NAME = "access-token";
+    public static final String REFRESH_COOKIE_NAME = "refresh-token";
 }

--- a/src/main/java/com/project/dasihaebom/global/constant/redis/RedisConstants.java
+++ b/src/main/java/com/project/dasihaebom/global/constant/redis/RedisConstants.java
@@ -12,9 +12,11 @@ public class RedisConstants {
     public static final String KEY_CODE_SUFFIX = ":code";
     public static final String KEY_COOLDOWN_SUFFIX = ":cooldown";
 
-    // LOGOUT
-    public static final String KEY_ACCESS_TOKEN_SUFFIX = ":Alogout";
-    public static final String KEY_REFRESH_TOKEN_SUFFIX = ":RToken";
+    // BLACK LIST
+    public static final String KEY_BLACK_LIST_SUFFIX = ":blacklist";
+
+    // JWT
+    public static final String KEY_REFRESH_SUFFIX = ":refresh";
 
     // SCOPE
     public static final String KEY_SCOPE_SUFFIX = ":scope";

--- a/src/main/java/com/project/dasihaebom/global/security/controller/SecurityController.java
+++ b/src/main/java/com/project/dasihaebom/global/security/controller/SecurityController.java
@@ -13,6 +13,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 
+import static com.project.dasihaebom.global.constant.common.CommonConstants.ACCESS_COOKIE_NAME;
+import static com.project.dasihaebom.global.constant.common.CommonConstants.REFRESH_COOKIE_NAME;
 import static com.project.dasihaebom.global.util.CookieUtils.createJwtCookies;
 import static com.project.dasihaebom.global.util.CookieUtils.getTokenFromCookies;
 
@@ -32,12 +34,12 @@ public class SecurityController {
             HttpServletRequest request,
             HttpServletResponse response
     ) {
-        String refreshToken = getTokenFromCookies(request, "refresh-token");
+        String refreshToken = getTokenFromCookies(request, REFRESH_COOKIE_NAME);
         String accessToken = securityService.reissueCookie(refreshToken);
 
         // 쿠키 재발급
         log.info("[ JwtAuthorizationFilter ] 쿠키를 재생성 합니다.");
-        createJwtCookies(response, "access-token", accessToken, jwtUtil.getAccessExpMs());
+        createJwtCookies(response, ACCESS_COOKIE_NAME, accessToken, jwtUtil.getAccessExpMs());
 
         return CustomResponse.onSuccess("엑세스 쿠키가 재발급 되었습니다.");
     }

--- a/src/main/java/com/project/dasihaebom/global/security/filter/CustomLoginFilter.java
+++ b/src/main/java/com/project/dasihaebom/global/security/filter/CustomLoginFilter.java
@@ -55,16 +55,16 @@ public class CustomLoginFilter extends UsernamePasswordAuthenticationFilter {
         //Request Body 에서 추출
         String loginId = requestBody.loginId(); //Email 추출
         String password = requestBody.password(); //password 추출
-        log.info("[ Login Filter ]  LoginId ---> {} ", loginId);
-        log.info("[ Login Filter ]  Password ---> {} ", password);
+//        log.info("[ Login Filter ]  LoginId ---> {} ", loginId);
+//        log.info("[ Login Filter ]  Password ---> {} ", password);
 
         //UserNamePasswordToken 생성 (인증용 객체)
         UsernamePasswordAuthenticationToken authToken
                 = new UsernamePasswordAuthenticationToken(loginId, password, null);
 
 
-        log.info("[ Login Filter ] 인증용 객체 UsernamePasswordAuthenticationToken 이 생성되었습니다. ");
-        log.info("[ Login Filter ] 인증을 시도합니다.");
+        log.info("[ Login Filter ] 인증용 객체 UsernamePasswordAuthenticationToken 생성");
+        log.info("[ Login Filter ] 인증 시도");
 
         //인증 시도
         return authenticationManager.authenticate(authToken);
@@ -79,7 +79,7 @@ public class CustomLoginFilter extends UsernamePasswordAuthenticationFilter {
             @NonNull Authentication authentication) throws IOException {
 
 
-        log.info("[ Login Filter ] 로그인에 성공 하였습니다.");
+        log.info("[ Login Filter ] 로그인 성공");
 
         CustomUserDetails customUserDetails = (CustomUserDetails)authentication.getPrincipal();
 
@@ -118,7 +118,7 @@ public class CustomLoginFilter extends UsernamePasswordAuthenticationFilter {
             @NonNull HttpServletResponse response,
             @NonNull AuthenticationException failed) throws IOException {
 
-        log.info("[ Login Filter ] 로그인에 실패하였습니다.");
+        log.info("[ Login Filter ] 로그인 실패");
 
         String errorCode;
         String errorMessage;

--- a/src/main/java/com/project/dasihaebom/global/security/filter/CustomLoginFilter.java
+++ b/src/main/java/com/project/dasihaebom/global/security/filter/CustomLoginFilter.java
@@ -26,6 +26,8 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 import java.io.IOException;
 
+import static com.project.dasihaebom.global.constant.common.CommonConstants.ACCESS_COOKIE_NAME;
+import static com.project.dasihaebom.global.constant.common.CommonConstants.REFRESH_COOKIE_NAME;
 import static com.project.dasihaebom.global.util.CookieUtils.createJwtCookies;
 
 @Slf4j
@@ -88,8 +90,8 @@ public class CustomLoginFilter extends UsernamePasswordAuthenticationFilter {
         long accessExp = jwtUtil.getAccessExpMs();
         long refreshExp = jwtUtil.getRefreshExpMs();
 
-        createJwtCookies(response, "access-token", accessToken, accessExp);
-        createJwtCookies(response, "refresh-token", refreshToken, refreshExp);
+        createJwtCookies(response, ACCESS_COOKIE_NAME, accessToken, accessExp);
+        createJwtCookies(response, REFRESH_COOKIE_NAME, refreshToken, refreshExp);
 
         //Client 에게 줄 Response 를 Build
         JwtDto jwtDto = JwtDto.builder()

--- a/src/main/java/com/project/dasihaebom/global/security/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/project/dasihaebom/global/security/filter/JwtAuthorizationFilter.java
@@ -90,17 +90,17 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
         Cookie[] cookies = request.getCookies();
         if (cookies != null) {
-            log.info("검색된 쿠키 : ");
+            log.info("[ JwtAuthorizationFilter ] 검색된 쿠키 -----------------------");
             for (Cookie cookie : cookies) {
-                log.info("쿠키명 : {}, 값 : {}", cookie.getName(), cookie.getValue().substring(0, 15));
+                log.info("[ JwtAuthorizationFilter ] 쿠키명 : {}, 값 : {}...", cookie.getName(), cookie.getValue().substring(0, 15));
             }
+            log.info("[ JwtAuthorizationFilter ] ---------------------------------");
         } else {
-            log.warn("현재 쿠키 자체가 없습니다");
+            log.warn("[ JwtAuthorizationFilter ] 현재 쿠키 없음");
         }
 
         try {
             // 1. Cookie 에서 Access Token 추출
-            log.info("access token 쿠키 검색");
             String accessToken = getTokenFromCookies(request, ACCESS_COOKIE_NAME);
 
             // 스웨거 전용 헤더에 토큰 넣기
@@ -114,22 +114,21 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
             // 2. Access Token이 없으면 다음 필터로 바로 진행
             if (accessToken == null) {
-                log.info("[ JwtAuthorizationFilter ] Access Token 없음, 다음 필터로 진행");
+                log.info("[ JwtAuthorizationFilter ] Access Token 없음, 다음 필터 진행");
                 filterChain.doFilter(request, response);
                 return;
             }
 
             log.info("[ JwtAuthorizationFilter ] 로그아웃 여부 확인");
-            log.info(jwtUtil.getJti(accessToken));
             if (Objects.equals(accessToken, redisUtils.get(jwtUtil.getJti(accessToken) + KEY_BLACK_LIST_SUFFIX))) {
-                log.info("[ JwtAuthorizationFilter ] 블랙리스트 토큰. 인증 생략하고 다음 필터로 진행");
+                log.info("[ JwtAuthorizationFilter ] 블랙리스트 토큰, 인증 생략 후 다음 필터 진행");
                 filterChain.doFilter(request, response);
                 return;
             }
 
             // 3. Access Token을 이용한 인증 처리
             authenticateAccessToken(accessToken);
-            log.info("[ JwtAuthorizationFilter ] 종료. 다음 필터로 넘어갑니다.");
+            log.info("[ JwtAuthorizationFilter ] 다음 필터 진행");
 
             filterChain.doFilter(request, response);
 
@@ -142,11 +141,11 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
     // Access Token을 바탕으로 인증 객체 생성 및 SecurityContext에 저장
     private void authenticateAccessToken(String accessToken) {
-        log.info("[ JwtAuthorizationFilter ] 토큰으로 인가 과정을 시작합니다. ");
+        log.info("[ JwtAuthorizationFilter ] 토큰으로 인가 과정을 시작");
 
         // 1. Access Token의 유효성 검증
         jwtUtil.validateToken(accessToken);
-        log.info("[ JwtAuthorizationFilter ] Access Token 유효성 검증 성공. ");
+        log.info("[ JwtAuthorizationFilter ] Access Token 유효성 검증 성공");
 
         // 2. Access Token에서 사용자 정보 추출 후 CustomUserDetails 생성
         Long userId = jwtUtil.getId(accessToken);

--- a/src/main/java/com/project/dasihaebom/global/security/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/project/dasihaebom/global/security/filter/JwtAuthorizationFilter.java
@@ -21,7 +21,8 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import java.io.IOException;
 import java.util.Objects;
 
-import static com.project.dasihaebom.global.constant.redis.RedisConstants.KEY_ACCESS_TOKEN_SUFFIX;
+import static com.project.dasihaebom.global.constant.common.CommonConstants.ACCESS_COOKIE_NAME;
+import static com.project.dasihaebom.global.constant.redis.RedisConstants.KEY_BLACK_LIST_SUFFIX;
 import static com.project.dasihaebom.global.util.CookieUtils.getTokenFromCookies;
 
 @Slf4j
@@ -100,7 +101,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
         try {
             // 1. Cookie 에서 Access Token 추출
             log.info("access token 쿠키 검색");
-            String accessToken = getTokenFromCookies(request, "access-token");
+            String accessToken = getTokenFromCookies(request, ACCESS_COOKIE_NAME);
 
             // 스웨거 전용 헤더에 토큰 넣기
 //            log.warn("\u001B[31m스\u001B[33m웨\u001B[32m거\u001B[36m \u001B[34m사\u001B[35m용\u001B[31m으\u001B[33m로\u001B[32m \u001B[36m쿠\u001B[34m키\u001B[35m \u001B[31m로\u001B[33m그\u001B[32m인\u001B[36m \u001B[34m방\u001B[35m식\u001B[31m을\u001B[33m \u001B[32m이\u001B[36m용\u001B[34m하\u001B[35m고\u001B[31m \u001B[33m있\u001B[32m지\u001B[36m \u001B[34m않\u001B[35m습\u001B[31m니\u001B[33m다\u001B[32m.\u001B[36m \u001B[34m서\u001B[35m버\u001B[31m \u001B[33m배\u001B[32m포\u001B[36m시\u001B[34m \u001B[35m제\u001B[31m거\u001B[0m");
@@ -119,7 +120,8 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
             }
 
             log.info("[ JwtAuthorizationFilter ] 로그아웃 여부 확인");
-            if (Objects.equals(accessToken, redisUtils.get(jwtUtil.getEmail(accessToken) + KEY_ACCESS_TOKEN_SUFFIX))) {
+            log.info(jwtUtil.getJti(accessToken));
+            if (Objects.equals(accessToken, redisUtils.get(jwtUtil.getJti(accessToken) + KEY_BLACK_LIST_SUFFIX))) {
                 log.info("[ JwtAuthorizationFilter ] 블랙리스트 토큰. 인증 생략하고 다음 필터로 진행");
                 filterChain.doFilter(request, response);
                 return;

--- a/src/main/java/com/project/dasihaebom/global/security/handler/CustomLogoutHandler.java
+++ b/src/main/java/com/project/dasihaebom/global/security/handler/CustomLogoutHandler.java
@@ -34,16 +34,7 @@ public class CustomLogoutHandler implements LogoutHandler {
         String loginId = jwtUtil.getEmail(refreshToken);
 
         jwtUtil.saveBlackListToken(loginId, accessToken, refreshToken);
-//
-//        // 로그아웃 블랙리스트 등록
-//        log.info("[ Redis 저장 ] key = Logout {}", loginId);
-//        redisUtils.save(loginId + KEY_BLACK_LIST_SUFFIX, refreshToken, jwtUtil.getRefreshExpMs(), TimeUnit.MILLISECONDS);
-//        redisUtils.save(loginId + KEY_BLACK_LIST_SUFFIX, accessToken, jwtUtil.getAccessExpMs(), TimeUnit.MILLISECONDS);
-//        log.info("[ CustomLogoutHandler ] Logout 블랙리스트 등록 완료");
-//
-//        redisUtils.delete(loginId + ":refresh");
-//        log.info("[ CustomLogoutHandler ] 블랙리스트 RefreshToken 삭제 완료");
-//
+
         createJwtCookies(response, ACCESS_COOKIE_NAME, null, 0);
         createJwtCookies(response, REFRESH_COOKIE_NAME, null, 0);
         log.info("[ CustomLogoutHandler ] 쿠키 삭제 완료");

--- a/src/main/java/com/project/dasihaebom/global/security/handler/CustomLogoutHandler.java
+++ b/src/main/java/com/project/dasihaebom/global/security/handler/CustomLogoutHandler.java
@@ -12,8 +12,9 @@ import org.springframework.stereotype.Component;
 
 import java.util.concurrent.TimeUnit;
 
-import static com.project.dasihaebom.global.constant.redis.RedisConstants.KEY_ACCESS_TOKEN_SUFFIX;
-import static com.project.dasihaebom.global.constant.redis.RedisConstants.KEY_REFRESH_TOKEN_SUFFIX;
+import static com.project.dasihaebom.global.constant.common.CommonConstants.ACCESS_COOKIE_NAME;
+import static com.project.dasihaebom.global.constant.common.CommonConstants.REFRESH_COOKIE_NAME;
+import static com.project.dasihaebom.global.constant.redis.RedisConstants.*;
 import static com.project.dasihaebom.global.util.CookieUtils.createJwtCookies;
 import static com.project.dasihaebom.global.util.CookieUtils.getTokenFromCookies;
 
@@ -28,21 +29,23 @@ public class CustomLogoutHandler implements LogoutHandler {
     @Override
     public void logout(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
 
-        String accessToken = getTokenFromCookies(request, "access-token");
-        String refreshToken = getTokenFromCookies(request, "refresh-token");
+        String accessToken = getTokenFromCookies(request, ACCESS_COOKIE_NAME);
+        String refreshToken = getTokenFromCookies(request, REFRESH_COOKIE_NAME);
         String loginId = jwtUtil.getEmail(refreshToken);
 
-        // 로그아웃 블랙리스트 등록
-        log.info("[ Redis 저장 ] key = Logout {}", loginId);
-        redisUtils.save(loginId + KEY_REFRESH_TOKEN_SUFFIX, refreshToken, jwtUtil.getRefreshExpMs(), TimeUnit.MILLISECONDS);
-        redisUtils.save(loginId + KEY_ACCESS_TOKEN_SUFFIX, accessToken, jwtUtil.getAccessExpMs(), TimeUnit.MILLISECONDS);
-        log.info("[ CustomLogoutHandler ] Logout 블랙리스트 등록 완료");
-
-        redisUtils.delete(loginId + ":refresh");
-        log.info("[ CustomLogoutHandler ] 블랙리스트 RefreshToken 삭제 완료");
-
-        createJwtCookies(response, "access-token", null, 0);
-        createJwtCookies(response, "refresh-token", null, 0);
+        jwtUtil.saveBlackListToken(loginId, accessToken, refreshToken);
+//
+//        // 로그아웃 블랙리스트 등록
+//        log.info("[ Redis 저장 ] key = Logout {}", loginId);
+//        redisUtils.save(loginId + KEY_BLACK_LIST_SUFFIX, refreshToken, jwtUtil.getRefreshExpMs(), TimeUnit.MILLISECONDS);
+//        redisUtils.save(loginId + KEY_BLACK_LIST_SUFFIX, accessToken, jwtUtil.getAccessExpMs(), TimeUnit.MILLISECONDS);
+//        log.info("[ CustomLogoutHandler ] Logout 블랙리스트 등록 완료");
+//
+//        redisUtils.delete(loginId + ":refresh");
+//        log.info("[ CustomLogoutHandler ] 블랙리스트 RefreshToken 삭제 완료");
+//
+        createJwtCookies(response, ACCESS_COOKIE_NAME, null, 0);
+        createJwtCookies(response, REFRESH_COOKIE_NAME, null, 0);
         log.info("[ CustomLogoutHandler ] 쿠키 삭제 완료");
     }
 }

--- a/src/main/java/com/project/dasihaebom/global/security/handler/CustomLogoutSuccessHandler.java
+++ b/src/main/java/com/project/dasihaebom/global/security/handler/CustomLogoutSuccessHandler.java
@@ -25,7 +25,7 @@ public class CustomLogoutSuccessHandler implements LogoutSuccessHandler {
             Authentication authentication
     ) throws IOException {
 
-        log.info("[ CustomLogoutSuccessHandler  ] 로그아웃에 성공 하였습니다.");
+        log.info("[ CustomLogoutSuccessHandler  ] 로그아웃 성공");
         // CustomResponse 사용하여 응답 통일
         CustomResponse<String> responseBody = CustomResponse.onSuccess("로그아웃 성공");
 

--- a/src/main/java/com/project/dasihaebom/global/security/service/SecurityService.java
+++ b/src/main/java/com/project/dasihaebom/global/security/service/SecurityService.java
@@ -30,7 +30,7 @@ public class SecurityService {
         }
 
         // refresh token의 유효성 검사
-        log.info("[ JwtAuthorizationFilter ] refresh token의 유효성을 검사합니다.");
+        log.info("[ reissueCookie ] refresh token의 유효성을 검사합니다.");
         jwtUtil.validateToken(refreshToken);
 
         // redis 에 해당 refresh token이 존재하는지 검사
@@ -40,7 +40,7 @@ public class SecurityService {
         }
 
         // access token 재발급
-        log.info("[ JwtAuthorizationFilter ] refresh token 으로 access token 을 생성합니다.");
+        log.info("[ reissueCookie ] refresh token 으로 access token 을 생성합니다.");
         return jwtUtil.reissueToken(refreshToken);
     }
 }

--- a/src/main/java/com/project/dasihaebom/global/security/service/SecurityService.java
+++ b/src/main/java/com/project/dasihaebom/global/security/service/SecurityService.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.Objects;
 
+import static com.project.dasihaebom.global.constant.redis.RedisConstants.KEY_REFRESH_SUFFIX;
 import static com.project.dasihaebom.global.util.CookieUtils.createJwtCookies;
 
 @Service
@@ -33,7 +34,7 @@ public class SecurityService {
         jwtUtil.validateToken(refreshToken);
 
         // redis 에 해당 refresh token이 존재하는지 검사
-        if (!Objects.equals(redisUtils.get(jwtUtil.getEmail(refreshToken) + ":refresh"), refreshToken)) {
+        if (!Objects.equals(redisUtils.get(jwtUtil.getEmail(refreshToken) + KEY_REFRESH_SUFFIX), refreshToken)) {
             // 서버에 리프레시 토큰이 없음 -> 재 로그인 안내
             throw new CustomException(SecurityErrorCode.REQUIRED_RE_LOGIN);
         }

--- a/src/main/java/com/project/dasihaebom/global/security/utils/JwtUtil.java
+++ b/src/main/java/com/project/dasihaebom/global/security/utils/JwtUtil.java
@@ -49,7 +49,6 @@ public class JwtUtil {
 
     // JWT 토큰을 입력으로 받아 토큰의 subject 로부터 사용자 Email 추출하는 메서드
     public String getEmail(String token) throws SignatureException {
-        log.info("[ JwtUtil ] 토큰에서 loginId를 추출합니다.");
         return Jwts.parser()
                 .verifyWith(secretKey)
                 .build()
@@ -60,7 +59,6 @@ public class JwtUtil {
 
     // JWT 토큰을 입력으로 받아 토큰의 claim 에서 사용자 권한을 추출하는 메서드
     public Role getRoles(String token) throws SignatureException{
-        log.info("[ JwtUtil ] 토큰에서 권한을 추출합니다.");
         String roleStr = Jwts.parser()
                 .verifyWith(secretKey)
                 .build()
@@ -71,7 +69,6 @@ public class JwtUtil {
     }
 
     public Long getId(String token) throws SignatureException{
-        log.info("[ JwtUtil ] 토큰에서 id를 추출합니다.");
         return Jwts.parser()
                 .verifyWith(secretKey)
                 .build()
@@ -81,7 +78,6 @@ public class JwtUtil {
     }
 
     public String getJti(String token) throws SignatureException{
-        log.info("[ JwtUtil ] 토큰에서 jti를 추출합니다.");
         return Jwts.parser()
                 .verifyWith(secretKey)
                 .build()
@@ -112,8 +108,6 @@ public class JwtUtil {
 
     // Token 발급하는 메서드
     public String tokenProvider(CustomUserDetails customUserDetails, Instant expiration) {
-
-        log.info("[ JwtUtil ] 토큰을 새로 생성합니다.");
         //현재 시간
         Instant issuedAt = Instant.now();
         // 토큰에 부여할 고유 jti
@@ -170,30 +164,30 @@ public class JwtUtil {
                 null,
                 getRoles(refreshToken)
         );
-        log.info("[ JwtUtil ] 새로운 토큰을 재발급 합니다.");
+        log.info("[ JwtUtil ] 새로운 토큰을 재발급");
 
         // 재발급
         return createJwtAccessToken(userDetails);
     }
 
-    // HTTP 요청의 'Authorization' 헤더에서 JWT 액세스 토큰을 검색
-    public String resolveAccessToken(HttpServletRequest request) {
-        log.info("[ JwtUtil ] 헤더에서 토큰을 추출합니다.");
-        String tokenFromHeader = request.getHeader("Authorization");
-
-        if (tokenFromHeader == null || !tokenFromHeader.startsWith("Bearer ")) {
-            log.warn("[ JwtUtil ] Request Header 에 토큰이 존재하지 않습니다.");
-            return null;
-        }
-
-        log.info("[ JwtUtil ] 헤더에 토큰이 존재합니다.");
-
-        return tokenFromHeader.split(" ")[1]; //Bearer 와 분리
-    }
+//    // HTTP 요청의 'Authorization' 헤더에서 JWT 액세스 토큰을 검색
+//    public String resolveAccessToken(HttpServletRequest request) {
+//        log.info("[ JwtUtil ] 헤더에서 토큰을 추출합니다.");
+//        String tokenFromHeader = request.getHeader("Authorization");
+//
+//        if (tokenFromHeader == null || !tokenFromHeader.startsWith("Bearer ")) {
+//            log.warn("[ JwtUtil ] Request Header 에 토큰이 존재하지 않습니다.");
+//            return null;
+//        }
+//
+//        log.info("[ JwtUtil ] 헤더에 토큰이 존재합니다.");
+//
+//        return tokenFromHeader.split(" ")[1]; //Bearer 와 분리
+//    }
 
 
     public void validateToken(String token) {
-        log.info("[ JwtUtil ] 토큰의 유효성을 검증합니다.");
+        log.info("[ JwtUtil ] 토큰의 유효성 검증");
         try {
             // 구문 분석 시스템의 시계가 JWT를 생성한 시스템의 시계 오차 고려
             // 약 3분 허용.
@@ -208,15 +202,15 @@ public class JwtUtil {
                     .getExpiration()
                     .before(new Date());
             if (isExpired) {
-                log.info("만료된 JWT 토큰입니다.");
+                log.info("만료된 JWT 토큰");
             }
 
         } catch (SecurityException | MalformedJwtException | UnsupportedJwtException | IllegalArgumentException e) {
             //원하는 Exception throw
-            throw new SecurityException("잘못된 토큰입니다.");
+            throw new SecurityException("잘못된 토큰");
         } catch (ExpiredJwtException e) {
             //원하는 Exception throw
-            throw new ExpiredJwtException(null, null, "만료된 JWT 토큰입니다.");
+            throw new ExpiredJwtException(null, null, "만료된 JWT 토큰");
         }
     }
 }

--- a/src/main/java/com/project/dasihaebom/global/util/CookieUtils.java
+++ b/src/main/java/com/project/dasihaebom/global/util/CookieUtils.java
@@ -26,21 +26,22 @@ public class CookieUtils {
     }
 
     public static String getTokenFromCookies(HttpServletRequest request, String cookieName) {
-        log.info("쿠키에서 토큰을 추출하기 위해 쿠키를 검색합니다.");
+        log.info("[ CookieUtils ] 쿠키 검색");
         if (request.getCookies() != null) {
             for (Cookie cookie : request.getCookies()) {
                 if (cookie.getName().equals(cookieName)) {
-                    log.info("{} 쿠키가 존재합니다.", cookieName);
+                    log.info("[ CookieUtils ] {} 쿠키 존재", cookieName);
                     return cookie.getValue();
                 }
             }
 
-            log.warn("사용 가능한 쿠키가 존재하지 않습니다.");
-            log.warn("현재 쿠키 목록");
+            log.warn("[ CookieUtils ] 사용 가능한 쿠키가 존재하지 않음");
+            log.warn("[ CookieUtils ] 현재 쿠키 목록 -------------------");
             for (Cookie cookie : request.getCookies()) {
-                log.warn(" - {}", cookie.getName());
+                log.warn("[ CookieUtils ]  - {}", cookie.getName());
+                log.warn("[ CookieUtils ] ------------------------------------");
             }
-            log.warn("accessToken 쿠키가 존재하지 않습니다.");
+            log.warn("[ CookieUtils ] {} 쿠키가 존재하지 않음", cookieName);
         }
         return null;
     }

--- a/src/main/java/com/project/dasihaebom/global/util/CookieUtils.java
+++ b/src/main/java/com/project/dasihaebom/global/util/CookieUtils.java
@@ -30,7 +30,7 @@ public class CookieUtils {
         if (request.getCookies() != null) {
             for (Cookie cookie : request.getCookies()) {
                 if (cookie.getName().equals(cookieName)) {
-                    log.info("accessToken 쿠키가 존재합니다.");
+                    log.info("{} 쿠키가 존재합니다.", cookieName);
                     return cookie.getValue();
                 }
             }


### PR DESCRIPTION
# ☝️Issue Number

- #9 

##  📌 개요

- 회원 탈퇴시에 쿠키가 사라집니다
- jti 사용
  - 기존에 블랙리스트를 저장하던 방식은 로그인+로그아웃을 두번하게 되면, 1번째 토큰들이 다시 살아나게되는데
  - jti를 jwt에 추가해서 토큰 고유 식별번호에 락을 걸어 막았습니다
  - 기타 짜잘한 매직넘버화 & 주석, 로그 수정

## 🔁 변경 사항

- 그렇습니다

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점